### PR TITLE
Fix use of dispatchEvent for older IE11 builds.

### DIFF
--- a/src/injector.js
+++ b/src/injector.js
@@ -321,5 +321,5 @@ window.FAI.bundleHost = window.FAI.bundleHost || '/';
     } else {
         event = newEvent('injectorReady');
     }
-    document.dispatchEvent(new Event('injectorReady'));
+    document.dispatchEvent(event);
 })(window.FAI, jQuery);

--- a/src/injector.js
+++ b/src/injector.js
@@ -319,7 +319,7 @@ window.FAI.bundleHost = window.FAI.bundleHost || '/';
         event = document.createEvent('Event');
         event.initEvent('injectorReady', false, true);
     } else {
-        event = newEvent('injectorReady');
+        event = new Event('injectorReady');
     }
     document.dispatchEvent(event);
 })(window.FAI, jQuery);

--- a/src/injector.js
+++ b/src/injector.js
@@ -25,6 +25,7 @@ window.FAI.bundleHost = window.FAI.bundleHost || '/';
         featureLoadSuccess,
         scanForFeature,
         loadUrl,
+        event,
         getBundleNameForFeatureName;
 
     /**
@@ -313,5 +314,12 @@ window.FAI.bundleHost = window.FAI.bundleHost || '/';
     };
 
     NS.INJECTOR.readyState = 'ready';
+    /* Not supposed to need to do this for IE11, but apparently we do... */
+    if (document.createEvent) {
+        event = document.createEvent('Event');
+        event.initEvent('injectorReady', false, true);
+    } else {
+        event = newEvent('injectorReady');
+    }
     document.dispatchEvent(new Event('injectorReady'));
 })(window.FAI, jQuery);


### PR DESCRIPTION
Apparently, older IE11 builds don't like initializing custom events with just the Event constructor, in spite of what Microsoft might say.  So, if the old way is still present, use it instead so older IE11's will work.